### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Bug report
+
+Provide a brief summary of your issue **AND** if reporting a build issue include the version/build number.
+
+## Feature request
+
+Provide a brief summary of the new feature required.
+
+**Please note by far the quickest way to get a new feature is to file a Pull Request.**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-## Bug report
-
-Provide a brief summary of your issue **AND** if reporting a build issue include the version/build number.
-
-## Feature request
-
-Provide a brief summary of the new feature required.
-
-**Please note by far the quickest way to get a new feature is to file a Pull Request.**

--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -1,0 +1,20 @@
+---
+name: "Bug Report"
+about: "You found something that is not working. Report it so that it can be fixed. 👷‍"
+title: "Fix: "
+labels: "type : bug"
+---
+
+## Issue
+
+Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
+ 
+## Expected
+
+Describe what should be the correct behaviour.
+ 
+## Steps to reproduce
+
+1. 
+2. 
+3. 

--- a/.github/ISSUE_TEMPLATE/FEATURE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_TEMPLATE.md
@@ -1,0 +1,14 @@
+---
+name: "Feature"
+about: "Open a feature issue to add new functionalities."
+title: "Add "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the big picture of the feature and why it's needed. 
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, clients...

--- a/.github/ISSUE_TEMPLATE/RFC_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/RFC_TEMPLATE.md
@@ -1,0 +1,28 @@
+---
+name: "Request For Comments (RFC)"
+about: "You have an idea on how to improve the template. Propose your idea so that the team can provide feedback."
+title: "RFC: "
+labels: "type : rfa"
+---
+
+## Issue
+
+Describe the issue from the template or generated project currently facing. Provide as much content as possible.
+
+## Solution
+
+Describe the solution you are prescribing for the issue.
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, clients...
+
+## What's Next?
+
+Provide an actionable list of things that must happen in order to implement the solution:
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+Using a poll is encouraged to gather feedback on the RFA 👉 Use this tool: https://gh-polls.com/

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Add the story URL here. Prefer the short link format, e.g. https://app.clubhouse.io/acme/story/1234/
+Closes #ISSUE_NUMBER
 
 ## What happened
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Add the story URL here. Prefer the short link format, e.g. https://app.clubhouse.io/acme/story/1234/
+
+## What happened
+
+Describe the big picture of your changes here to communicate to the team why we should accept this pull request. 
+ 
+## Insight
+
+Describe in details how to test the changes, which solution you tried but did not go with, referenced documentation is welcome as well.
+ 
+## Proof Of Work
+
+Show us the implementation: screenshots, gif, etc.

--- a/.github/PULL_REQUEST_TEMPLATE/RELEASE_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/RELEASE_TEMPLATE.md
@@ -1,0 +1,17 @@
+Link to the milestone on Github e.g. https://github.com/nimblehq/git-templates/milestone/41?closed=1
+or
+Link to the project management tool for the release
+
+## Features
+
+Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
+
+- [ch1234] As a user, I can log in
+  or
+- [[ch1234](https://github.com/nimblehq/git-templates/issues/1234)] As a user, I can log in
+
+## Chores
+- Same structure as in  ## Feature
+
+## Bugs
+- Same structure as in  ## Feature


### PR DESCRIPTION
Closes #2 

## What happened

- Add issue templates (Bug, feature, RFC)
- Add PR template
- Add Release template 

## Insight

Copied from our other repositories, e.g. https://github.com/nimblehq/elixir-templates/tree/develop/.github

## Proof Of Work

Templates should render as intended 🎉 