### PR TITLE
Fix: Bad substitution Error when missing variables 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ TEMP_CLONE_WIKI_FOLDER="tmp_wiki"
 COMMIT_MSG="Update Wiki content"
 
 function error() {
-  echo "::error file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
+  echo "::error::$1"
 }
 
 function add_mask() {


### PR DESCRIPTION
Closes #6 

## What happened

✅. Remove BASH_SOURCE and BASH_LINENO from error message
 
## Proof Of Work

Workflow working as intended.
<img width="596" alt="Screen Shot 2022-04-12 at 5 11 48 PM" src="https://user-images.githubusercontent.com/34730459/162937903-d8b7b6f5-b764-48e4-9139-91c2ef072d93.png">

