### PR TITLE
Fix: Unsafe working directory due to latest Git security vulnerability fix

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,11 @@ add_mask "${USER_ACCESS_TOKEN}"
 {
   mkdir $TEMP_CLONE_WIKI_FOLDER
   cd $TEMP_CLONE_WIKI_FOLDER || exit 1
+
+  # Add Safe Directory to initialize sub repo
+  git config --global --add safe.directory "/github/workspace"
+  git config --global --add safe.directory "/github/workspace/$TEMP_CLONE_WIKI_FOLDER"
+
   git init
   git config user.name $USER_NAME
   git config user.email $USER_EMAIL


### PR DESCRIPTION
Closes #8 

## What happened

✅ Mark the temp wiki directory as safe and can successfully initialize the sub repo

## Insight

More insight in the issue https://github.com/nimblehq/publish-github-wiki-action/issues/8 📖 

Following the instructions in the error, we're forced to mark the temp wiki folder where we initialize git to be a safe directory
This is due to the latest changes in git https://github.blog/2022-04-12-git-security-vulnerability-announced/  📰 
 
## Proof Of Work

After testing on another repo the fix in https://github.com/nimblehq/publish-github-wiki-action/releases/tag/v0.1.0-alpha-4
It successfully pushes to the wiki

![Screen Shot 2022-10-28 at 3 41 05 PM](https://user-images.githubusercontent.com/34730459/198544702-a48db92c-acd7-4a91-83ef-d30c532aabc3.png)

